### PR TITLE
feat(notion): add data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The following connectors are currently available:
 - ✅ Files (.md, .txt, .pdf, .csv)
 - ✅ GitHub (Private and Public repos)
 - ✅ Google Drive
+- ✅ Notion (pages, [need to grant access](https://github.com/mendableai/data-connectors/issues/8#issuecomment-1917829463))
 - ✅ Text
 - ✅ Web Scraper (single urls, sitemap)
 - ✅ Zendesk
 - 🔄 Confluence (In progress)
 - 🔄 Jira (In progress)
-- 🔄 Notion (In progress)
 - 🔄 YouTube (In progress)
 
 We are working hard on transitioning all of our connectors to this repository. If you need a connector that is not available here, please open an issue or submit a PR.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     },
     "dependencies": {
         "@nangohq/node": "^0.36.100",
+        "@notionhq/client": "^2.2.14",
         "@octokit/auth-oauth-user": "^4.0.1",
         "axios": "^1.6.5",
         "cheerio": "^1.0.0-rc.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@nangohq/node':
     specifier: ^0.36.100
     version: 0.36.100
+  '@notionhq/client':
+    specifier: ^2.2.14
+    version: 2.2.14
   '@octokit/auth-oauth-user':
     specifier: ^4.0.1
     version: 4.0.1
@@ -1877,6 +1880,16 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
+  /@notionhq/client@2.2.14:
+    resolution: {integrity: sha512-oqUefZtCiJPCX+74A1Os9OVTef3fSnVWe2eVQtU1HJSD+nsfxfhwvDKnzJTh2Tw1ZHKLxpieHB/nzGdY+Uo12A==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@types/node-fetch': 2.6.11
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@octokit/app@14.0.2:
     resolution: {integrity: sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==}
     engines: {node: '>= 18'}
@@ -2324,6 +2337,13 @@ packages:
     resolution: {integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==}
     dependencies:
       '@types/node': 20.11.7
+    dev: false
+
+  /@types/node-fetch@2.6.11:
+    resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
+    dependencies:
+      '@types/node': 20.11.7
+      form-data: 4.0.0
     dev: false
 
   /@types/node@20.11.7:

--- a/src/__tests__/providers/Notion/index.test.ts
+++ b/src/__tests__/providers/Notion/index.test.ts
@@ -1,0 +1,34 @@
+import { createDataConnector } from "../../../DataConnector";
+import dotenv from "dotenv";
+dotenv.config();
+
+test(
+  "Notion Provider Testing",
+  async () => {
+    const notionDataConnector = createDataConnector({
+      provider: "notion",
+    });
+
+    if (!process.env.NANGO_CONNECTION_ID_TEST) {
+      throw new Error(
+        "Please specify the NANGO_CONNECTION_ID_TEST environment variable."
+      );
+    }
+
+    await notionDataConnector.authorizeNango({
+      nango_connection_id: process.env.NANGO_CONNECTION_ID_TEST,
+    });
+
+    const pages = await notionDataConnector.getDocuments();
+    expect(pages.length).toBeGreaterThan(0);
+    pages.forEach((page) => {
+      expect(page.provider).toBe("notion");
+      expect(page.type).toBe("page");
+      expect(page.content).not.toBe(null);
+      expect(page.createdAt).not.toBe(undefined);
+      expect(page.updatedAt).not.toBe(undefined);
+      expect(page.metadata.sourceURL).not.toBe(null);
+    });
+  },
+  30 * 1000
+); // 30 seconds

--- a/src/providers/Notion/index.ts
+++ b/src/providers/Notion/index.ts
@@ -7,10 +7,8 @@ import {
   BlockObjectResponse,
   ListBlockChildrenResponse,
   PageObjectResponse,
-  PartialPageObjectResponse,
   RichTextItemResponse,
   SearchResponse,
-  TextRichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 
 export type NotionInputOptions = object;
@@ -75,6 +73,10 @@ async function recursiveBlockChildren(
   return blocks;
 }
 
+/**
+ * Converts a Notion rich text item to Markdown.
+ * Thoroughly supports TextRichTextItems, dumps the plain_text value for others (equations, mentions).
+ */
 function textItemToMarkdown(item: RichTextItemResponse): string {
   if (item.type === "text") {
     let md = "";

--- a/src/providers/Notion/index.ts
+++ b/src/providers/Notion/index.ts
@@ -1,0 +1,362 @@
+import { Nango } from "@nangohq/node";
+import { Client } from "@notionhq/client";
+import { DataProvider } from "../DataProvider";
+import { Document } from "../../entities/Document";
+import { NangoAuthorizationOptions } from "../GoogleDrive";
+import {
+  BlockObjectResponse,
+  ListBlockChildrenResponse,
+  PageObjectResponse,
+  PartialPageObjectResponse,
+  RichTextItemResponse,
+  SearchResponse,
+  TextRichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+
+export type NotionInputOptions = object;
+
+export type NotionAuthorizationOptions = {
+  token?: string;
+};
+
+export interface NotionOptions
+  extends NotionInputOptions,
+    NotionAuthorizationOptions,
+    NangoAuthorizationOptions {}
+
+/**
+ * Represents a Notion block and its children, which are also blocks that may themselves have children too.
+ */
+export type NotionBlockWithChildren = {
+  block: BlockObjectResponse;
+  children: NotionBlockWithChildren[];
+};
+
+/**
+ * Represents a Notion page and its blocks.
+ */
+type NotionPageWithBlocks = {
+  page: PageObjectResponse;
+  blocks: NotionBlockWithChildren[];
+};
+
+/**
+ * Recursively retrieves the children of a block.
+ *
+ * @param notion The (initialized, authenticated) Notion client.
+ * @param block_id The block ID to retrive all children of.
+ */
+async function recursiveBlockChildren(
+  notion: Client,
+  block_id: string
+): Promise<NotionBlockWithChildren[]> {
+  const blocks: NotionBlockWithChildren[] = [];
+  let req: ListBlockChildrenResponse;
+  const i = 0;
+
+  do {
+    req = await notion.blocks.children.list({ block_id });
+
+    const results = req.results as BlockObjectResponse[];
+
+    for (const block of results) {
+      // Using recursive function calls in here is fine,
+      // because we use (real) async functions,
+      // so the call stack will not overflow.
+      blocks.push({
+        block,
+        children: block.has_children
+          ? await recursiveBlockChildren(notion, block.id)
+          : [],
+      });
+    }
+  } while (req.has_more);
+
+  return blocks;
+}
+
+function textItemToMarkdown(item: RichTextItemResponse): string {
+  if (item.type === "text") {
+    let md = "";
+
+    if (item.annotations.code) {
+      md += "```";
+    }
+
+    if (item.annotations.bold) {
+      md += "**";
+    }
+
+    if (item.annotations.italic) {
+      md += "*";
+    }
+
+    if (item.annotations.strikethrough) {
+      md += "~~";
+    }
+
+    const mdEnd = [...md].reverse().join("");
+
+    return (
+      md +
+      (item.text.link
+        ? `[${item.text.content}](${item.text.link.url})`
+        : item.text.content) +
+      mdEnd
+    );
+  } else {
+    return item.plain_text;
+  }
+}
+
+/**
+ * Converts an array of rich text items to plain text.
+ */
+function blockToMarkdown(
+  block: BlockObjectResponse,
+  listLevel: number
+): { md: string | null; isList: boolean } {
+  let md = "",
+    isList = false,
+    suffix = "\n\n";
+
+  if (block.type === "heading_1") {
+    md = "# ";
+  } else if (block.type === "heading_2") {
+    md = "## ";
+  } else if (block.type === "heading_3") {
+    md = "### ";
+  } else if (block.type == "bulleted_list_item") {
+    md = "  ".repeat(listLevel) + "- ";
+    suffix = "\n";
+    isList = true;
+  } else if (block.type == "numbered_list_item") {
+    // Markdown renderers automatically increment numbers in ordered lists if every list number is 1.
+    // We can't get the proper list numbers anyways (Notion numbered lists don't always start at one, and the API doesn't expose it), so why bother?
+    md = "  ".repeat(listLevel) + "1. ";
+    suffix = "\n";
+    isList = true;
+  } else if (block.type === "quote") {
+    // Add quote character to the start of the line
+    return {
+      md: block.quote.rich_text
+        .map((item) => textItemToMarkdown(item))
+        .join("")
+        .split("\n")
+        .map((line) => "> " + line)
+        .join("\n"),
+      isList: false,
+    };
+  } else if (block.type === "divider") {
+    md = "---";
+  } else if (block.type === "table") {
+    // Quick and dirty table hack
+    return { md: "", isList };
+  } else if (block.type === "table_row") {
+    // Quick and dirty table row hack
+    // Headerless tables are not supported by some Markdown renderers, but it should be enough.
+    return {
+      md:
+        "|" +
+        block.table_row.cells
+          .map((cell) => cell.map((item) => textItemToMarkdown(item)).join(""))
+          .join("|") +
+        "|\n",
+      isList: false,
+    };
+  } else if (block.type === "image") {
+    const caption = block.image[block.image.type].caption;
+    md = `![${
+      caption
+        ? caption.map((item) => textItemToMarkdown(item)).join("")
+        : "image"
+    }](${block.image[block.image.type].url})`;
+  } else if (block.type === "link_preview") {
+    return {
+      md: `[${block.link_preview.url}](${block.link_preview.url})`,
+      isList: false,
+    };
+  }
+
+  const rich_text: RichTextItemResponse[] | undefined =
+    block[block.type].rich_text;
+
+  if (rich_text !== undefined) {
+    md += rich_text.map((item) => textItemToMarkdown(item)).join("");
+  }
+
+  if (block.type === "code") {
+    md =
+      "```" + (block.code.language ?? "") + "\n" + md.replace(/```/g, "`\v``"); // prevent code block escapes
+  }
+
+  if (md.length === 0 && rich_text === undefined) {
+    // Block type is unsupported by Markdown and it doesn't have a plain text conversion from the Notion API.
+    return { md: null, isList };
+  } else {
+    return { md: md + suffix, isList };
+  }
+}
+
+/**
+ * Converts blocks and their children (recursively) to Markdown.
+ */
+function blocksToMarkdown(blocks: NotionBlockWithChildren[]): string {
+  const output = [];
+
+  // Using recursive function calls in here is NOT fine,
+  // because big pages will exceed the call stack limit,
+  // so shenanigans have to ensue.
+
+  let currentBlocks: {
+    block: NotionBlockWithChildren;
+    ref: any[];
+    listLevel: number;
+  }[] = blocks.map((block) => ({ block, ref: output, listLevel: 0 }));
+
+  while (currentBlocks.length > 0) {
+    const nextBlocks: typeof currentBlocks = [];
+    for (const {
+      block: { block, children },
+      ref,
+      listLevel,
+    } of currentBlocks) {
+      const listContext = {
+        listLevel,
+        listNumber: 1,
+      };
+
+      const { md, isList } = blockToMarkdown(block, listLevel) ?? {
+        md: null,
+        isList: false,
+      };
+
+      if (md !== null) {
+        ref.push(md);
+      }
+
+      const next = [];
+      ref.push(next);
+
+      for (const block of children) {
+        nextBlocks.push({
+          block,
+          ref: next,
+          listLevel: listLevel + (isList ? 1 : 0),
+        });
+      }
+    }
+    currentBlocks = nextBlocks;
+  }
+
+  return output.flat(Infinity).join("");
+}
+
+/**
+ * The Notion Data Provider retrieves all pages from a Notion workspace.
+ */
+export class NotionDataProvider implements DataProvider<NotionOptions> {
+  private notion: Client = undefined;
+
+  /**
+   * Authorizes the Notion Data Provider.
+   * **The Notion integration must have the "Read content" capability.**
+   */
+  async authorize(options: NotionAuthorizationOptions): Promise<void> {
+    if (options.token === undefined || options.token === null) {
+      throw new Error("options.token is required.");
+    }
+
+    this.notion = new Client({
+      auth: options.token,
+    });
+  }
+
+  /**
+   * Authorizes the Notion Data Provider via Nango.
+   * **The Notion integration must have the "Read content" capability.**
+   */
+  async authorizeNango(options: NangoAuthorizationOptions): Promise<void> {
+    if (!process.env.NANGO_SECRET_KEY) {
+      throw new Error(
+        "Nango secret key is required. Please specify it in the NANGO_SECRET_KEY environment variable."
+      );
+    }
+    const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY });
+
+    const connection = await nango.getConnection(
+      options.nango_integration_id ?? "notion",
+      options.nango_connection_id
+    );
+
+    await this.authorize({
+      token: connection.credentials.raw.access_token,
+    });
+  }
+
+  /**
+   * Retrieves all authorized pages from the authorized Notion workspace.
+   * The pages' content will be converted to Markdown.
+   */
+  async getDocuments(): Promise<Document[]> {
+    if (this.notion === undefined) {
+      throw Error(
+        "You must authorize the NotionDataProvider before requesting documents."
+      );
+    }
+
+    const all: NotionPageWithBlocks[] = [];
+
+    let req: SearchResponse = undefined;
+
+    do {
+      req = await this.notion.search({
+        start_cursor: req?.next_cursor,
+        filter: {
+          property: "object",
+          value: "page",
+        },
+        page_size: 100,
+      });
+
+      const pages = req.results.filter(
+        (x) => x.object === "page"
+      ) as PageObjectResponse[];
+
+      const pagesWithBlocks: NotionPageWithBlocks[] = await Promise.all(
+        pages.map(async (page) => {
+          return {
+            page,
+            blocks: await recursiveBlockChildren(this.notion, page.id),
+          };
+        })
+      );
+
+      all.push(...pagesWithBlocks);
+    } while (req.has_more);
+
+    const pages = all.map(({ page, blocks }) => {
+      return {
+        page,
+        content: blocksToMarkdown(blocks),
+      };
+    });
+
+    return pages.map(({ page, content }) => ({
+      provider: "notion",
+      id: page.id,
+      createdAt: new Date(page.created_time),
+      updatedAt: new Date(page.last_edited_time),
+      content,
+      metadata: {
+        sourceURL: page.public_url ?? page.url,
+      },
+      type: "page",
+    }));
+  }
+
+  /**
+   * Do not call. The Notion Data Provider doesn't have any integrations.
+   */
+  setOptions(_options: NotionOptions): void {}
+}

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -12,6 +12,11 @@ import {
   GoogleDriveInputOptions,
   NangoAuthorizationOptions,
 } from "./GoogleDrive/index";
+import {
+  NotionAuthorizationOptions,
+  NotionDataProvider,
+  NotionInputOptions,
+} from "./Notion";
 import { TextDataProvider, TextInputOptions } from "./Text";
 import { WebScraperDataProvider, WebScraperOptions } from "./WebScraper/index";
 import { ZendeskDataProvider, ZendeskInputOptions } from "./Zendesk";
@@ -28,6 +33,7 @@ export const providers: Provider = {
   confluence: new ConfluenceDataProvider(),
   "github": new GitHubDataProvider(),
   file: new FileDataProvider(),
+  "notion": new NotionDataProvider(),
 };
 
 // Define a single source of truth for all providers and their associated types
@@ -74,6 +80,12 @@ type ProviderConfig = {
     AuthorizeOptions: FileInputOptions;
     NangoAuthorizeOptions: any;
   }
+  "notion": {
+    DataProvider: NotionDataProvider;
+    Options: NotionInputOptions;
+    AuthorizeOptions: NotionAuthorizationOptions;
+    NangoAuthorizeOptions: NangoAuthorizationOptions;
+  };
   // Add other providers here...
 };
 


### PR DESCRIPTION
Fixes #8 
/claim #8 

Retrieves all (accessible) pages from a Notion workspace, including nested pages in databases, like described in #8. Converts the page contents to Markdown. I brought my own Markdown converter, reads a bit dodgy, but works just fine (not my first time doing that lol). No huge dependencies either :D

Linked the GIF I sent to #8 as access granting instructions in the README.