### PR TITLE
feat(confluence): add Confluence Data Provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "async": "^3.2.5",
         "axios": "^1.6.5",
         "cheerio": "^1.0.0-rc.12",
+        "confluence.js": "^1.7.2",
         "dotenv": "^16.4.1",
         "glob": "^10.3.10",
         "googleapis": "^131.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   cheerio:
     specifier: ^1.0.0-rc.12
     version: 1.0.0-rc.12
+  confluence.js:
+    specifier: ^1.7.2
+    version: 1.7.2
   dotenv:
     specifier: ^16.4.1
     version: 16.4.1
@@ -2729,6 +2732,14 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: false
 
+  /atlassian-jwt@2.0.3:
+    resolution: {integrity: sha512-G9oO3HHS1UKgsLRXj6nNKv2TY6g3PleBCdzHwbFeVKg+18GBFIMRz+ApxuOuWAgcL7RngNFF5rGNtw1Ss3hvTg==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      jsuri: 1.3.1
+      lodash: 4.17.21
+    dev: false
+
   /axios-retry@3.9.1:
     resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
     dependencies:
@@ -3132,6 +3143,18 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
+
+  /confluence.js@1.7.2:
+    resolution: {integrity: sha512-hCHC4tZNikLonSJdKjcc7CQa5XuWFVyzn5iCKYAtDs7lXWmQyzRoc7mTnKGgMDYNOOCuK+vVIwf9nEcecWXOtw==}
+    dependencies:
+      atlassian-jwt: 2.0.3
+      axios: 1.6.5
+      form-data: 4.0.0
+      oauth: 0.10.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4735,6 +4758,10 @@ packages:
       semver: 7.5.4
     dev: false
 
+  /jsuri@1.3.1:
+    resolution: {integrity: sha512-LLdAeqOf88/X0hylAI7oSir6QUsz/8kOW0FcJzzu/SJRfORA/oPHycAOthkNp7eLPlTAbqVDFbqNRHkRVzEA3g==}
+    dev: false
+
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
     dependencies:
@@ -4858,6 +4885,10 @@ packages:
 
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+    dev: false
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /lru-cache@10.2.0:
@@ -5019,6 +5050,10 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
+    dev: false
+
+  /oauth@0.10.0:
+    resolution: {integrity: sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==}
     dev: false
 
   /object-assign@4.1.1:

--- a/src/__tests__/providers/Confluence/index.test.ts
+++ b/src/__tests__/providers/Confluence/index.test.ts
@@ -1,0 +1,34 @@
+import { createDataConnector } from "../../../DataConnector";
+import dotenv from "dotenv";
+dotenv.config();
+
+test(
+  "Confluence Provider Testing",
+  async () => {
+    const confluenceDataConnector = createDataConnector({
+      provider: "confluence",
+    });
+
+    if (!process.env.NANGO_CONNECTION_ID_TEST) {
+      throw new Error(
+        "Please specify the NANGO_CONNECTION_ID_TEST environment variable."
+      );
+    }
+
+    await confluenceDataConnector.authorizeNango({
+      nango_connection_id: process.env.NANGO_CONNECTION_ID_TEST,
+    });
+
+    const pages = await confluenceDataConnector.getDocuments();
+    expect(pages.length).toBeGreaterThan(0);
+    pages.forEach((issue) => {
+      expect(issue.provider).toBe("confluence");
+      expect(issue.type).toBe("page");
+      expect(issue.content).not.toBe(null);
+      expect(issue.createdAt).not.toBe(undefined);
+      expect(issue.updatedAt).not.toBe(undefined);
+      expect(issue.metadata.sourceURL).not.toBe(null);
+    });
+  },
+  10 * 1000
+); // 10 seconds

--- a/src/providers/Confluence/index.ts
+++ b/src/providers/Confluence/index.ts
@@ -53,6 +53,8 @@ async function getAllPages(
 export class ConfluenceDataProvider implements DataProvider<ConfluenceOptions> {
   private confluence: ConfluenceClient = undefined;
 
+  private cloudUrl: string = "";
+
   /**
    * Authorizes the Confluence Data Provider.
    */
@@ -98,6 +100,7 @@ export class ConfluenceDataProvider implements DataProvider<ConfluenceOptions> {
     );
 
     const cloudId = access.data[0].id;
+    this.cloudUrl = access.data[0].url
 
     await this.authorize({
       host: `https://api.atlassian.com/ex/confluence/${cloudId}`,
@@ -132,7 +135,7 @@ export class ConfluenceDataProvider implements DataProvider<ConfluenceOptions> {
           createdAt: new Date((page as any).history.createdDate),
           updatedAt: new Date((page as any).history.lastUpdated.when),
           metadata: {
-            sourceURL: page._links.self,
+            sourceURL: this.cloudUrl + "/wiki" + page._links.webui,
             ancestor: ancestor?.title,
           },
           type: "page",

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -1,8 +1,7 @@
 import {
-  ConfluenceAuthorizeOptions,
+  ConfluenceAuthorizationOptions,
   ConfluenceDataProvider,
   ConfluenceInputOptions,
-  NangoConfluenceAuthorizationOptions,
 } from "./Confluence";
 import { DataProvider } from "./DataProvider";
 import { FileDataProvider, FileInputOptions } from "./File";
@@ -78,8 +77,8 @@ type ProviderConfig = {
   confluence: {
     DataProvider: ConfluenceDataProvider;
     Options: ConfluenceInputOptions;
-    AuthorizeOptions: ConfluenceAuthorizeOptions;
-    NangoAuthorizeOptions: NangoConfluenceAuthorizationOptions;
+    AuthorizeOptions: ConfluenceAuthorizationOptions;
+    NangoAuthorizeOptions: NangoAuthorizationOptions;
   };
   github: {
     DataProvider: GitHubDataProvider;


### PR DESCRIPTION
Closes #2 
/claim #2 

This PR adds a data provider that retrieves all pages from Confluence, like described in #2. The content of the pages are HTML-like.
